### PR TITLE
Updating Transformers Dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 spacy>=3.4.0,<4.0.0
-transformers>=3.4.0,<4.22.0
+transformers==4.23.1
 torch>=1.6.0
 srsly>=2.4.0,<3.0.0
 dataclasses>=0.6,<1.0; python_version < "3.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ include_package_data = true
 python_requires = >=3.6
 install_requires =
     spacy>=3.4.0,<4.0.0
-    transformers>=3.4.0,<4.22.0
+    transformers==4.23.1
     torch>=1.6.0
     srsly>=2.4.0,<3.0.0
     dataclasses>=0.6,<1.0; python_version < "3.7"


### PR DESCRIPTION
Updating the transformers dependency removes the need for rust compiler on M1.